### PR TITLE
Use goto instead of teleport for compatibility

### DIFF
--- a/Files/ball.py
+++ b/Files/ball.py
@@ -6,9 +6,9 @@ class ball:
         self.tutel.shape("circle")
         self.tutel.color("white")
         self.tutel.penup()
-        self.tutel.teleport(0,0)
+        self.tutel.goto(0,0)
         self.xspeed = 10
         self.yspeed = 10
         
     def move(self):
-        self.tutel.teleport(self.tutel.xcor()+self.xspeed,self.tutel.ycor()+self.yspeed)
+        self.tutel.goto(self.tutel.xcor()+self.xspeed,self.tutel.ycor()+self.yspeed)

--- a/main.py
+++ b/main.py
@@ -8,13 +8,13 @@ screen = turtle.Screen()
 art = turtle.Turtle()
 
 def get_screen_lengths():
-    width = turtle.window_width()
-    height = turtle.window_height()
+    width = screen.window_width()
+    height = screen.window_height()
     return (width, height)
 screen.tracer(0,0)
 screen.bgcolor('black')
 
-art.teleport(5,-4000)
+art.goto(5,-4000)
 art.lt(90)
 art.ht()
 art.color('white')
@@ -46,22 +46,22 @@ scoreboard.pu()
 while True:
     time.sleep(0.05)
     scoreboard.clear()
-    paddle.tutel.teleport(get_screen_lengths()[0]/2-50,paddle.tutel.ycor())
-    paddleAI.tutel.teleport(-get_screen_lengths()[0]/2+50,paddleAI.tutel.ycor())
+    paddle.tutel.goto(get_screen_lengths()[0]/2-50,paddle.tutel.ycor())
+    paddleAI.tutel.goto(-get_screen_lengths()[0]/2+50,paddleAI.tutel.ycor())
     ball.move()
-    paddleAI.tutel.teleport(-get_screen_lengths()[0]/2+50,ball.tutel.ycor())
+    paddleAI.tutel.goto(-get_screen_lengths()[0]/2+50,ball.tutel.ycor())
     # if paddleAI.direction == "up":
     #     paddleAI.go_up()
     # else:
     #     paddleAI.go_down()
     if paddle.tutel.ycor() > get_screen_lengths()[1]/2+75:
-        paddle.tutel.teleport(paddle.tutel.xcor(),-get_screen_lengths()[1]/2-75)
+        paddle.tutel.goto(paddle.tutel.xcor(),-get_screen_lengths()[1]/2-75)
     elif paddle.tutel.ycor() < -get_screen_lengths()[1]/2-75:
-        paddle.tutel.teleport(paddle.tutel.xcor(),get_screen_lengths()[1]/2+75)
+        paddle.tutel.goto(paddle.tutel.xcor(),get_screen_lengths()[1]/2+75)
     if paddleAI.tutel.ycor() > get_screen_lengths()[1]/2+75:
-        paddleAI.tutel.teleport(paddleAI.tutel.xcor(),-get_screen_lengths()[1]/2-75)
+        paddleAI.tutel.goto(paddleAI.tutel.xcor(),-get_screen_lengths()[1]/2-75)
     elif paddleAI.tutel.ycor() < -get_screen_lengths()[1]/2-75:
-        paddleAI.tutel.teleport(paddleAI.tutel.xcor(),get_screen_lengths()[1]/2+75)
+        paddleAI.tutel.goto(paddleAI.tutel.xcor(),get_screen_lengths()[1]/2+75)
     
     if i == 100:
         i=0
@@ -84,7 +84,7 @@ while True:
         ball.xspeed *= -1
 
     scoreboard.write(f"Player: {paddle.score}      AI: {paddleAI.score}",align="right",font=("Arial",24,"normal"))
-    scoreboard.teleport(100,get_screen_lengths()[1]/2-50)
+    scoreboard.goto(0,get_screen_lengths()[1]/2-50)
     screen.update()
 screen.exitonclick()
 


### PR DESCRIPTION
I noticed that the `Turtle.teleport` method doesn't exist in earlier versions of Python, and it was causing some issues. To fix this, I replaced all instances of `Turtle.teleport` with `Turtle.goto` throughout the project. Now everything should work smoothly!